### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
     "perl" : "6.*",
     "name" : "IO::Prompt",
+    "license" : "Artistic-2.0",
     "version" : "0.0.2",
     "description" : "This is a generic module for interactive prompting from the console.",
     "authors" : [ "pnu", "wbiker" ],


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license